### PR TITLE
 Switch from 'glob' package to 'fast-glob' 

### DIFF
--- a/cli/commands/upload.js
+++ b/cli/commands/upload.js
@@ -3,7 +3,7 @@ const program = require('commander');
 const colors = require('colors');
 const fs = require('fs');
 const FileStore = require('../../lib/filestore');
-const glob = require('glob');
+const glob = require('fast-glob');
 
 function UploadCommand () {
     return program
@@ -42,7 +42,7 @@ function UploadCommand () {
             if (fs.existsSync('.nwabaprc')) {
                 Object.assign(options, JSON.parse(fs.readFileSync('.nwabaprc', 'utf8')));
             }
-            
+
             Object.keys(options).map(key => {
                 if (_options[key] !== undefined) {
                     options[key] = _options[key];
@@ -107,7 +107,7 @@ function UploadCommand () {
 
                 glob.sync(options.files, {
                     cwd: options.base,
-                    nodir: true
+                    onlyFiles: true
                 }).map(file => {
                     files.push(file);
                 });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "colors": "^1.1.2",
     "commander": "^2.13.0",
     "figlet": "^1.2.0",
-    "glob": "^7.1.2",
+    "fast-glob": "^2.2.6",
     "gulp-util": "^3.0.8",
     "isbinaryfile": "^3.0.2",
     "resolve": "^1.5.0",


### PR DESCRIPTION
Changed to fast glob becuase of it's support of multiple and negated patterns (['*', '!*.md']).

this would allow an configuration like.

```json
{
  "files": [
    "**/*.*",
    "!resources/**/*.*",
    "resources/sap-ui-custom.js",
    "resources/mylib/**/themes/myTheme/**/*.{css,json}",
    "resources/mylib/**/assets/**/*.*",
    "!resources/mylib/**/samples/**/*.*",
    "resources/sap/**/themes/myTheme/**/*.{css,json}"
  ]
}
```