### PR TITLE
Fix usestrictssl option.

### DIFF
--- a/cli/commands/upload.js
+++ b/cli/commands/upload.js
@@ -149,6 +149,7 @@ function UploadCommand () {
             filestore.syncFiles(files, options.base, function (err) {
                 if (err) {
                     console.log(colors.red('Error!'), err);
+		    process.exitCode = 1;
                 }
             });
         });

--- a/cli/commands/upload.js
+++ b/cli/commands/upload.js
@@ -92,7 +92,10 @@ function UploadCommand () {
             // Information messages
             if (options.conn_usestrictssl === true || options.conn_usestrictssl === "true" || options.conn_usestrictssl === "1") {
                 validation.information.push('If HTTPS is used, strict SSL enabled!');
-            }
+		options.conn_usestrictssl = true
+            } else {
+		options.conn_usestrictssl = false
+	    }
 
             validation.information.map(msg => {
                 console.log(colors.blue(msg));


### PR DESCRIPTION
The --conn_usestrictssl option is not working.

When I tried to deploy to a server using self-signed with the nwabap command, I got the following error.

```
root@ba42b27cf2fd:/project/ytest20201013# nwabap upload --base $BASEDIR --conn_server $CONN_SERVER --conn_client $CONN_CLIENT --conn_user $CONN_USER --conn_password $CONN_PASSWORD --conn_usestrictssl false --abap_package $ABAP_PACKAGE --abap_bsp $ABAP_BSP --abap_bsp_text "UI5 upload test objects" --abap_transport $TR | grep -v Request-Url
Found 34 files. Starting upload...
Request-Method: get
Error: self signed certificate
Details: 
undefined
root@ba42b27cf2fd:/project/ytest20201013#
```

I think it's because the useStrictSSL option on line 75 of lib / filestore.js requires a boolean type but receives the string "false".