### PR TITLE
Add an option to deploy files which start with dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Added support for files_start_with_dot
+
 ## 1.1.0
 
 - Removed unused package

--- a/cli/commands/upload.js
+++ b/cli/commands/upload.js
@@ -44,7 +44,8 @@ function UploadCommand() {
                 calcappindex: false,
                 git_diff_commit: "",
                 git_diff_unstaged: false,
-                preserve_unselected: false
+                preserve_unselected: false,
+                files_start_with_dot : false
             };
 
             if (fs.existsSync(_options.nwabaprc)) {
@@ -129,7 +130,8 @@ function UploadCommand() {
                 } else {
                     files = glob.sync(options.files, {
                         cwd: options.base,
-                        onlyFiles: true
+                        onlyFiles: true,
+                        dot : options.files_start_with_dot
                     });
                 }
             } catch(e) {


### PR DESCRIPTION
This pull request contains changes, which allow user to optionally select files that start with dot (i.e. ".library") to be deployed to SAP. 

Related issue:  https://github.com/nrdev88/nwabap-ui5uploader/issues/21

The fast-glob has got the 'dot' option set by default to **false**. However, it was not possible to change this parameter using the 'upload' command of nwabap-ui5uploader. I have added an option called 'files_start_with_dot' (also by default set to false):
![image](https://user-images.githubusercontent.com/68218263/115354815-53fcd680-a1ba-11eb-8cca-e7b5642fec10.png)
Which in turn is pass to the fast-glob:
![image](https://user-images.githubusercontent.com/68218263/115354945-7858b300-a1ba-11eb-867c-186bb939d4a2.png)

The 'files_start_with_dot' can be set in the **.nwabaprc** file:
_"files_start_with_dot" : "true"_

Without this additional option the ".library" file was not being deployed to SAP and the custom SAPUI5 library could not be used (was not recognized as a library in SAPUI5 app using manifest.json->"sap.ui5"->"dependencies"->"libs" ).